### PR TITLE
Replace 'Reset' button

### DIFF
--- a/FixCode/FixCode.m
+++ b/FixCode/FixCode.m
@@ -11,6 +11,18 @@
 #import "Aspects.h"
 #import "FixCode.h"
 
+@interface IDEEnhancedProvisioningSigningIdentity : NSObject
+
+@property NSUInteger state; // 0: current, 2: online-only
+
+@end
+
+@interface IDESigningIdentityActionCellViewContents : NSObject
+
+@property IDEEnhancedProvisioningSigningIdentity *signingIdentity;
+
+@end
+
 @interface NSObject (Shutup)
 
 -(void)_autoLayoutViewViewFrameDidChange:(id)arg0;
@@ -160,6 +172,16 @@
         [self findAndReplaceFixIssueButtonInView:view];
     } error:&error];
 
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+    
+    [objc_getClass("IDESigningIdentityActionCellView") aspect_hookSelector:@selector(setObjectValue:) withOptions:AspectPositionAfter usingBlock:^(id<AspectInfo> info, IDESigningIdentityActionCellViewContents *cellContents) {
+        if ([[cellContents signingIdentity] state] == 2) {
+            [self findAndReplaceFixIssueButtonInView:info.instance];
+        }
+    } error:&error];
+    
     if (error) {
         NSLog(@"Error: %@", error);
     }


### PR DESCRIPTION
Replaces the Reset button for distribution profiles when the private key is missing.

![screen shot 2016-05-18 at 12 54 46](https://cloud.githubusercontent.com/assets/252173/15359970/febf5edc-1d0b-11e6-9903-f41e6899d96c.png)
➔
<img width="481" alt="screen shot 2016-05-18 at 15 01 46" src="https://cloud.githubusercontent.com/assets/252173/15359971/fee0c608-1d0b-11e6-8c2d-c2a5512fd0cb.png">
